### PR TITLE
Feature: Basic Tweeting capabilities

### DIFF
--- a/reqbaz/build.gradle
+++ b/reqbaz/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'commons-io:commons-io:2.8.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.9'
+    implementation 'io.github.redouane59.twitter:twittered:2.15'
 }
 
 configurations {

--- a/reqbaz/etc/de.rwth.dbis.acis.bazaar.service.BazaarService.properties
+++ b/reqbaz/etc/de.rwth.dbis.acis.bazaar.service.BazaarService.properties
@@ -11,5 +11,7 @@ smtpServer=
 emailFromAddress=
 emailSummaryTimePeriodInMinutes=
 monitor=''
+twitterApiKey=
+twitterApiKeySecret=
 twitterClientId=
 twitterClientSecret=

--- a/reqbaz/etc/de.rwth.dbis.acis.bazaar.service.BazaarService.properties
+++ b/reqbaz/etc/de.rwth.dbis.acis.bazaar.service.BazaarService.properties
@@ -11,3 +11,5 @@ smtpServer=
 emailFromAddress=
 emailSummaryTimePeriodInMinutes=
 monitor=''
+twitterClientId=
+twitterClientSecret=

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/BazaarService.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/BazaarService.java
@@ -67,7 +67,6 @@ import javax.ws.rs.core.Response;
 import javax.xml.bind.DatatypeConverter;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
@@ -105,6 +104,8 @@ public class BazaarService extends RESTService {
     protected String smtpServer;
     protected String emailFromAddress;
     protected String emailSummaryTimePeriodInMinutes;
+    protected String twitterApiKey;
+    protected String twitterApiKeySecret;
     protected String twitterClientId;
     protected String twitterClientSecret;
 
@@ -160,7 +161,7 @@ public class BazaarService extends RESTService {
 
         }
 
-        tweetDispatcher = new TweetDispatcher(twitterClientId, twitterClientSecret);
+        tweetDispatcher = new TweetDispatcher(twitterApiKey, twitterApiKeySecret, twitterClientId, twitterClientSecret);
 
         notificationDispatcher.setBazaarService(this);
     }

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/BazaarService.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/BazaarService.java
@@ -39,6 +39,7 @@ import de.rwth.dbis.acis.bazaar.service.notification.NotificationDispatcher;
 import de.rwth.dbis.acis.bazaar.service.notification.NotificationDispatcherImp;
 import de.rwth.dbis.acis.bazaar.service.resources.*;
 import de.rwth.dbis.acis.bazaar.service.security.AuthorizationManager;
+import de.rwth.dbis.acis.bazaar.service.twitter.TweetDispatcher;
 import i5.las2peer.api.Context;
 import i5.las2peer.api.ManualDeployment;
 import i5.las2peer.api.ServiceException;
@@ -88,6 +89,7 @@ public class BazaarService extends RESTService {
     private final ValidatorFactory validatorFactory;
     private final List<BazaarFunctionRegistrar> functionRegistrar;
     private final NotificationDispatcher notificationDispatcher;
+    private final TweetDispatcher tweetDispatcher;
     private final DataSource dataSource;
 
     //CONFIG PROPERTIES
@@ -103,6 +105,8 @@ public class BazaarService extends RESTService {
     protected String smtpServer;
     protected String emailFromAddress;
     protected String emailSummaryTimePeriodInMinutes;
+    protected String twitterClientId;
+    protected String twitterClientSecret;
 
     public BazaarService() throws Exception {
         setFieldValues();
@@ -156,6 +160,8 @@ public class BazaarService extends RESTService {
 
         }
 
+        tweetDispatcher = new TweetDispatcher(twitterClientId, twitterClientSecret);
+
         notificationDispatcher.setBazaarService(this);
     }
 
@@ -181,6 +187,7 @@ public class BazaarService extends RESTService {
         //getResourceConfig().register(PersonalisationDataResource.class);
         getResourceConfig().register(FeedbackResource.class);
         getResourceConfig().register(WebhookResource.class);
+        getResourceConfig().register(AdminResource.class);
     }
 
     public String getBaseURL() {
@@ -216,6 +223,10 @@ public class BazaarService extends RESTService {
 
     public NotificationDispatcher getNotificationDispatcher() {
         return notificationDispatcher;
+    }
+
+    public TweetDispatcher getTweetDispatcher() {
+        return tweetDispatcher;
     }
 
     private void registerUserAtFirstLogin() throws Exception {

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/DALFacade.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/DALFacade.java
@@ -30,6 +30,7 @@ import de.rwth.dbis.acis.bazaar.service.exception.BazaarException;
 import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Optional;
 
 
 public interface DALFacade {
@@ -830,4 +831,21 @@ public interface DALFacade {
      */
     void untagRequirement(int tagId, int requirementId) throws Exception;
     // endregion tags
+
+
+    // region LinkedTwitterAccount
+
+    /**
+     * returns the currently linked account
+     *
+     * @return
+     * @throws BazaarException
+     */
+    Optional<LinkedTwitterAccount> getLinkedTwitterAccount() throws BazaarException;
+
+    void replaceLinkedTwitterAccount(LinkedTwitterAccount newLinkedAccount) throws Exception;
+
+    void updateLinkedTwitterAccount(LinkedTwitterAccount linkedTwitterAccount) throws Exception;
+
+    // endregion LinkedTwitterAccount
 }

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/DALFacadeImpl.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/DALFacadeImpl.java
@@ -71,6 +71,7 @@ public class DALFacadeImpl implements DALFacade {
     private FeedbackRepository feedbackRepository;
     private TagRepository tagRepository;
     private RequirementTagRepository requirementTagRepository;
+    private LinkedTwitterAccountRepository linkedTwitterAccountRepository;
 
     public DALFacadeImpl(DataSource dataSource, SQLDialect dialect) {
         dslContext = DSL.using(dataSource, dialect);
@@ -959,4 +960,37 @@ public class DALFacadeImpl implements DALFacade {
         roleRepository = (roleRepository != null) ? roleRepository : new RoleRepositoryImpl(dslContext);
         return roleRepository.listProjectMembers(projectId, pageable);
     }
+
+    // region LinkedTwitterAccount
+
+    @Override
+    public Optional<LinkedTwitterAccount> getLinkedTwitterAccount() throws BazaarException {
+        linkedTwitterAccountRepository = (linkedTwitterAccountRepository != null)
+                ? linkedTwitterAccountRepository : new LinkedTwitterAccountRepositoryImpl(dslContext);
+        return linkedTwitterAccountRepository.findCurrentlyLinked();
+    }
+
+    @Override
+    public void replaceLinkedTwitterAccount(LinkedTwitterAccount newLinkedAccount) throws Exception {
+        linkedTwitterAccountRepository = (linkedTwitterAccountRepository != null)
+                ? linkedTwitterAccountRepository : new LinkedTwitterAccountRepositoryImpl(dslContext);
+
+        // ensure we only store 1 linked account at once
+        // so first, remove all existing
+        for (LinkedTwitterAccount linkedAccounts : linkedTwitterAccountRepository.findAll()) {
+            linkedTwitterAccountRepository.delete(linkedAccounts.getId());
+        }
+
+        linkedTwitterAccountRepository.add(newLinkedAccount);
+    }
+
+    @Override
+    public void updateLinkedTwitterAccount(LinkedTwitterAccount linkedTwitterAccount) throws Exception {
+        linkedTwitterAccountRepository = (linkedTwitterAccountRepository != null)
+                ? linkedTwitterAccountRepository : new LinkedTwitterAccountRepositoryImpl(dslContext);
+
+        linkedTwitterAccountRepository.update(linkedTwitterAccount);
+    }
+
+    // endregion LinkedTwitterAccount
 }

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/entities/LinkedTwitterAccount.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/entities/LinkedTwitterAccount.java
@@ -1,0 +1,38 @@
+package de.rwth.dbis.acis.bazaar.service.dal.entities;
+
+import java.time.OffsetDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(builderClassName = "Builder")
+public class LinkedTwitterAccount extends EntityBase {
+
+    private int id;
+
+    private int linkedByUserId;
+
+    private OffsetDateTime creationDate;
+
+    private OffsetDateTime lastUpdatedDate;
+
+    private String twitterUsername;
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    private OffsetDateTime expirationDate;
+
+    public void updateToken(String accessToken, String refreshToken, OffsetDateTime expirationDate) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expirationDate = expirationDate;
+        this.lastUpdatedDate = OffsetDateTime.now();
+    }
+
+    public boolean isTokenExpired() {
+        return OffsetDateTime.now().isAfter(expirationDate);
+    }
+}

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/repositories/LinkedTwitterAccountRepository.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/repositories/LinkedTwitterAccountRepository.java
@@ -1,0 +1,17 @@
+package de.rwth.dbis.acis.bazaar.service.dal.repositories;
+
+import java.util.Optional;
+
+import de.rwth.dbis.acis.bazaar.service.dal.entities.LinkedTwitterAccount;
+import de.rwth.dbis.acis.bazaar.service.exception.BazaarException;
+
+public interface LinkedTwitterAccountRepository extends Repository<LinkedTwitterAccount> {
+
+    /**
+     * Returns the Twitter account that is currently linked to the ReqBaz instance. May be an empty optional
+     * if no account is linked.
+     *
+     * @return
+     */
+    Optional<LinkedTwitterAccount> findCurrentlyLinked() throws BazaarException;
+}

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/repositories/LinkedTwitterAccountRepositoryImpl.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/repositories/LinkedTwitterAccountRepositoryImpl.java
@@ -1,0 +1,25 @@
+package de.rwth.dbis.acis.bazaar.service.dal.repositories;
+
+import java.util.Optional;
+
+import de.rwth.dbis.acis.bazaar.dal.jooq.tables.records.LinkedTwitterAccountRecord;
+import de.rwth.dbis.acis.bazaar.service.dal.entities.LinkedTwitterAccount;
+import de.rwth.dbis.acis.bazaar.service.dal.helpers.PageInfo;
+import de.rwth.dbis.acis.bazaar.service.dal.transform.LinkedTwitterAccountTransformer;
+import de.rwth.dbis.acis.bazaar.service.exception.BazaarException;
+import org.jooq.DSLContext;
+
+public class LinkedTwitterAccountRepositoryImpl extends RepositoryImpl<LinkedTwitterAccount, LinkedTwitterAccountRecord> implements LinkedTwitterAccountRepository {
+
+    /**
+     * @param jooq DSLContext for JOOQ connection
+     */
+    public LinkedTwitterAccountRepositoryImpl(DSLContext jooq) {
+        super(jooq, new LinkedTwitterAccountTransformer());
+    }
+
+    @Override
+    public Optional<LinkedTwitterAccount> findCurrentlyLinked() throws BazaarException {
+        return findAll(new PageInfo(0, 1)).stream().findFirst();
+    }
+}

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/transform/LinkedTwitterAccountTransformer.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/transform/LinkedTwitterAccountTransformer.java
@@ -1,0 +1,97 @@
+package de.rwth.dbis.acis.bazaar.service.dal.transform;
+
+import java.util.*;
+
+import de.rwth.dbis.acis.bazaar.dal.jooq.tables.records.LinkedTwitterAccountRecord;
+import de.rwth.dbis.acis.bazaar.service.dal.entities.LinkedTwitterAccount;
+import de.rwth.dbis.acis.bazaar.service.dal.helpers.Pageable;
+import org.jooq.*;
+
+import static de.rwth.dbis.acis.bazaar.dal.jooq.Tables.LINKED_TWITTER_ACCOUNT;
+
+public class LinkedTwitterAccountTransformer implements Transformer<LinkedTwitterAccount, LinkedTwitterAccountRecord> {
+
+    @Override
+    public LinkedTwitterAccountRecord createRecord(LinkedTwitterAccount entity) {
+        LinkedTwitterAccountRecord record = new LinkedTwitterAccountRecord();
+        record.setId(entity.getId());
+        record.setLinkedByUserId(entity.getLinkedByUserId());
+        record.setCreationDate(entity.getCreationDate());
+        record.setLastUpdatedDate(entity.getLastUpdatedDate());
+        record.setTwitterUsername(entity.getTwitterUsername());
+        record.setAccessToken(entity.getAccessToken());
+        record.setRefreshToken(entity.getRefreshToken());
+        record.setExpirationDate(entity.getExpirationDate());
+        return record;
+    }
+
+    @Override
+    public LinkedTwitterAccount getEntityFromTableRecord(LinkedTwitterAccountRecord record) {
+        return LinkedTwitterAccount.builder()
+                .id(record.getId())
+                .linkedByUserId(record.getLinkedByUserId())
+                .creationDate(record.getCreationDate())
+                .lastUpdatedDate(record.getLastUpdatedDate())
+                .twitterUsername(record.getTwitterUsername())
+                .accessToken(record.getAccessToken())
+                .refreshToken(record.getRefreshToken())
+                .expirationDate(record.getExpirationDate())
+                .build();
+    }
+
+    @Override
+    public Table<LinkedTwitterAccountRecord> getTable() {
+        return LINKED_TWITTER_ACCOUNT;
+    }
+
+    @Override
+    public TableField<LinkedTwitterAccountRecord, Integer> getTableId() {
+        return LINKED_TWITTER_ACCOUNT.ID;
+    }
+
+    @Override
+    public Class<? extends LinkedTwitterAccountRecord> getRecordClass() {
+        return LinkedTwitterAccountRecord.class;
+    }
+
+    @Override
+    public Map<Field, Object> getUpdateMap(LinkedTwitterAccount entity) {
+        HashMap<Field, Object> updateMap = new HashMap<>() {{
+
+            if (entity.getTwitterUsername() != null) {
+                put(LINKED_TWITTER_ACCOUNT.TWITTER_USERNAME, entity.getTwitterUsername());
+            }
+            if (entity.getAccessToken() != null) {
+                put(LINKED_TWITTER_ACCOUNT.ACCESS_TOKEN, entity.getAccessToken());
+            }
+            if (entity.getRefreshToken() != null) {
+                put(LINKED_TWITTER_ACCOUNT.REFRESH_TOKEN, entity.getRefreshToken());
+            }
+            if (entity.getExpirationDate() != null) {
+                put(LINKED_TWITTER_ACCOUNT.EXPIRATION_DATE, entity.getExpirationDate());
+            }
+            if (entity.getLastUpdatedDate() != null) {
+                put(LINKED_TWITTER_ACCOUNT.LAST_UPDATED_DATE, entity.getLastUpdatedDate());
+            }
+        }};
+        return updateMap;
+    }
+
+    @Override
+    public Collection<? extends SortField<?>> getSortFields(List<Pageable.SortField> sorts) {
+        if (sorts.isEmpty()) {
+            return Collections.singletonList(LINKED_TWITTER_ACCOUNT.ID.asc());
+        }
+        return null;
+    }
+
+    @Override
+    public Condition getSearchCondition(String search) throws Exception {
+        throw new Exception("Search is not supported!");
+    }
+
+    @Override
+    public Collection<? extends Condition> getFilterConditions(Map<String, String> filters) throws Exception {
+        return new ArrayList<>();
+    }
+}

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -63,23 +64,26 @@ public class AdminResource {
     }
 
     @POST
-    @Path("/trigger-weekly-tweet")
+    @Path("/twitter/test-tweet")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Tweet latest projects")
+    @ApiOperation(value = "Post a test Tweet on twitter")
     @ApiResponses(value = {
             @ApiResponse(code = HttpURLConnection.HTTP_CREATED, message = "Returns OK"),
             @ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "Not found"),
             @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Internal server problems")
     })
-    public Response triggerTweet() {
+    public Response postTestTweet() {
         return handleAuthenticatedRequest(
                 SystemRole.SystemAdmin.name(),
                 "Only Administrators can manually trigger a tweet",
                 ((dalFacade, internalUserId) -> {
                     //// actual operation - start
 
-                    bazaarService.getTweetDispatcher().publishTweet(dalFacade,"Hello World! (from ReqBaz), refactored");
+                    int randomNumber = new Random().nextInt(4242);
+
+                    bazaarService.getTweetDispatcher().publishTweet(dalFacade,
+                            "Hello World! (from ReqBaz). Here's some random number: " + randomNumber);
 
                     Map<String, Object> response = new HashMap<>();
                     response.put("success", true);
@@ -91,7 +95,7 @@ public class AdminResource {
 
                     //// actual operation - end
                 }),
-                "Triggering weekly Tweet manually failed"
+                "Posting a test Tweet failed"
         );
     }
 

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
@@ -93,7 +93,7 @@ public class AdminResource {
 
             //// actual operation -start
 
-            bazaarService.getTweetDispatcher().publishTweet("Hello World! (from ReqBaz)");
+            bazaarService.getTweetDispatcher().publishTweet("Hello World! (from ReqBaz), refactored");
 
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
@@ -1,0 +1,163 @@
+package de.rwth.dbis.acis.bazaar.service.resources;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import de.rwth.dbis.acis.bazaar.service.BazaarFunction;
+import de.rwth.dbis.acis.bazaar.service.BazaarService;
+import de.rwth.dbis.acis.bazaar.service.dal.DALFacade;
+import de.rwth.dbis.acis.bazaar.service.dal.entities.SystemRole;
+import de.rwth.dbis.acis.bazaar.service.exception.BazaarException;
+import de.rwth.dbis.acis.bazaar.service.exception.ErrorCode;
+import de.rwth.dbis.acis.bazaar.service.exception.ExceptionHandler;
+import de.rwth.dbis.acis.bazaar.service.exception.ExceptionLocation;
+import de.rwth.dbis.acis.bazaar.service.internalization.Localization;
+import de.rwth.dbis.acis.bazaar.service.security.AuthorizationManager;
+import i5.las2peer.api.Context;
+import i5.las2peer.api.logging.MonitoringEvent;
+import i5.las2peer.api.security.Agent;
+import i5.las2peer.logging.L2pLogger;
+import io.swagger.annotations.*;
+
+/**
+ * Parent endpoint for global, administrative operations and queries
+ */
+@Api(value = "webhook")
+@SwaggerDefinition(
+        info = @Info(
+                title = "Requirements Bazaar",
+                version = "0.9.0",
+                description = "Requirements Bazaar project",
+                termsOfService = "http://requirements-bazaar.org",
+                contact = @Contact(
+                        name = "Requirements Bazaar Dev Team",
+                        url = "http://requirements-bazaar.org",
+                        email = "info@requirements-bazaar.org"
+                ),
+                license = @License(
+                        name = "Apache2",
+                        url = "http://requirements-bazaar.org/license"
+                )
+        ),
+        schemes = SwaggerDefinition.Scheme.HTTPS
+)
+@Path("/admin")
+public class AdminResource {
+
+    private L2pLogger logger = L2pLogger.getInstance(AdminResource.class.getName());
+    private BazaarService bazaarService;
+
+    @javax.ws.rs.core.Context
+    UriInfo uriInfo;
+
+    public AdminResource() throws Exception {
+        bazaarService = (BazaarService) Context.getCurrent().getService();
+    }
+
+    @POST
+    @Path("/trigger-weekly-tweet")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Tweet latest projects")
+    @ApiResponses(value = {
+            @ApiResponse(code = HttpURLConnection.HTTP_CREATED, message = "Returns OK"),
+            @ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "Not found"),
+            @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Internal server problems")
+    })
+    public Response triggerTweet(){
+        DALFacade dalFacade = null;
+        try {
+            Agent agent = Context.getCurrent().getMainAgent();
+            String userId = agent.getIdentifier();
+            String registrarErrors = bazaarService.notifyRegistrars(EnumSet.of(BazaarFunction.VALIDATION, BazaarFunction.USER_FIRST_LOGIN_HANDLING));
+            if (registrarErrors != null) {
+                ExceptionHandler.getInstance().throwException(ExceptionLocation.BAZAARSERVICE, ErrorCode.UNKNOWN, registrarErrors);
+            }
+            dalFacade = bazaarService.getDBConnection();
+            Integer internalUserId = dalFacade.getUserIdByLAS2PeerId(userId);
+
+            boolean authorized = new AuthorizationManager().isAuthorized(internalUserId, dalFacade.getRoleByName(SystemRole.SystemAdmin.name()), dalFacade);
+            if (!authorized) {
+                ExceptionHandler.getInstance().throwException(ExceptionLocation.BAZAARSERVICE, ErrorCode.AUTHORIZATION, "Only Administrators can manually trigger a tweet");
+            }
+
+            //// actual operation -start
+
+            bazaarService.getTweetDispatcher().publishTweet("Hello World! (from ReqBaz)");
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            //// actual operation - end
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+            String json = mapper.writeValueAsString(response);
+            return Response.ok(json).build();
+        } catch (BazaarException bex) {
+            if (bex.getErrorCode() == ErrorCode.AUTHORIZATION) {
+                return Response.status(Response.Status.UNAUTHORIZED).entity(ExceptionHandler.getInstance().toJSON(bex)).build();
+            } else {
+                Context.get().monitorEvent(MonitoringEvent.SERVICE_ERROR, "Triggering weekly Tweet failed");
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(ExceptionHandler.getInstance().toJSON(bex)).build();
+            }
+        } catch (Exception ex) {
+            BazaarException bex = ExceptionHandler.getInstance().convert(ex, ExceptionLocation.BAZAARSERVICE, ErrorCode.UNKNOWN, ex.getMessage());
+            Context.get().monitorEvent(MonitoringEvent.SERVICE_ERROR, "Automated Tweet failed");
+            logger.warning(bex.getMessage());
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(ExceptionHandler.getInstance().toJSON(bex)).build();
+        }
+    }
+
+    @GET
+    @Path("/twitter/authorize")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Authorize ReqBaz to control a certain Twitter account.")
+    @ApiResponses(value = {
+            @ApiResponse(code = HttpURLConnection.HTTP_CREATED, message = "Returns OK"),
+            @ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "Not found"),
+            @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Internal server problems")
+    })
+    public Response authorizeTwitterAccount() {
+
+        String redirectUri = buildTwitterAuthRedirectUri();
+        logger.info("redirectUri: " + redirectUri);
+        String authorizationUrl = bazaarService.getTweetDispatcher().getAuthorizationUrl(redirectUri);
+
+        return Response.seeOther(URI.create(authorizationUrl)).build();
+    }
+
+    @GET
+    @Path("/twitter/auth-cb")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Redirect callback after Twitter account authorized RqBaz for account control")
+    @ApiResponses(value = {
+            @ApiResponse(code = HttpURLConnection.HTTP_CREATED, message = "Returns OK"),
+            @ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "Not found"),
+            @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Internal server problems")
+    })
+    public Response twitterAuthCallback(@QueryParam("code") String code) {
+
+        bazaarService.getTweetDispatcher().handleAuthCallback(buildTwitterAuthRedirectUri(), code);
+
+        return Response.ok().build();
+    }
+
+    private String buildTwitterAuthRedirectUri() {
+        return uriInfo.getBaseUriBuilder()
+                .path(AdminResource.class)
+                .path(AdminResource.class, "twitterAuthCallback")
+                .build().toString();
+    }
+}

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,7 +20,6 @@ import de.rwth.dbis.acis.bazaar.service.exception.BazaarException;
 import de.rwth.dbis.acis.bazaar.service.exception.ErrorCode;
 import de.rwth.dbis.acis.bazaar.service.exception.ExceptionHandler;
 import de.rwth.dbis.acis.bazaar.service.exception.ExceptionLocation;
-import de.rwth.dbis.acis.bazaar.service.internalization.Localization;
 import de.rwth.dbis.acis.bazaar.service.security.AuthorizationManager;
 import i5.las2peer.api.Context;
 import i5.las2peer.api.logging.MonitoringEvent;
@@ -81,7 +79,7 @@ public class AdminResource {
                 ((dalFacade, internalUserId) -> {
                     //// actual operation - start
 
-                    bazaarService.getTweetDispatcher().publishTweet("Hello World! (from ReqBaz), refactored");
+                    bazaarService.getTweetDispatcher().publishTweet(dalFacade,"Hello World! (from ReqBaz), refactored");
 
                     Map<String, Object> response = new HashMap<>();
                     response.put("success", true);
@@ -131,11 +129,12 @@ public class AdminResource {
             @ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "Not found"),
             @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Internal server problems")
     })
-    public Response twitterAuthCallback(@QueryParam("code") String code) {
+    public Response twitterAuthCallback(@QueryParam("code") String code) throws Exception {
         /*
          * No authentication here, because this callback is called by Twitter during authentication.
          */
-        bazaarService.getTweetDispatcher().handleAuthCallback(buildTwitterAuthRedirectUri(), code);
+        bazaarService.getTweetDispatcher().handleAuthCallback(bazaarService.getDBConnection(),
+                buildTwitterAuthRedirectUri(), code);
 
         return Response.ok().build();
     }

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
@@ -108,12 +108,17 @@ public class AdminResource {
             @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Internal server problems")
     })
     public Response authorizeTwitterAccount() {
+        return handleAuthenticatedRequest(
+                SystemRole.SystemAdmin.name(),
+                "SystemAdmin role is required to link ReqBaz Twitter account",
+                (dalFacade, internalUserId) -> {
+                    String redirectUri = buildTwitterAuthRedirectUri();
+                    logger.info("redirectUri: " + redirectUri);
+                    String authorizationUrl = bazaarService.getTweetDispatcher().getAuthorizationUrl(redirectUri);
 
-        String redirectUri = buildTwitterAuthRedirectUri();
-        logger.info("redirectUri: " + redirectUri);
-        String authorizationUrl = bazaarService.getTweetDispatcher().getAuthorizationUrl(redirectUri);
-
-        return Response.seeOther(URI.create(authorizationUrl)).build();
+                    return Response.seeOther(URI.create(authorizationUrl)).build();
+                },
+                "Failed to init Twitter authentication process");
     }
 
     @GET
@@ -127,7 +132,9 @@ public class AdminResource {
             @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Internal server problems")
     })
     public Response twitterAuthCallback(@QueryParam("code") String code) {
-
+        /*
+         * No authentication here, because this callback is called by Twitter during authentication.
+         */
         bazaarService.getTweetDispatcher().handleAuthCallback(buildTwitterAuthRedirectUri(), code);
 
         return Response.ok().build();

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/AdminResource.java
@@ -118,7 +118,13 @@ public class AdminResource {
                     logger.info("redirectUri: " + redirectUri);
                     String authorizationUrl = bazaarService.getTweetDispatcher().getAuthorizationUrl(redirectUri);
 
-                    return Response.seeOther(URI.create(authorizationUrl)).build();
+                    Map<String, Object> response = new HashMap<>();
+                    response.put("redirectUri", authorizationUrl);
+
+                    ObjectMapper mapper = new ObjectMapper();
+                    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+                    String json = mapper.writeValueAsString(response);
+                    return Response.ok(json).build();
                 },
                 "Failed to init Twitter authentication process");
     }
@@ -140,7 +146,7 @@ public class AdminResource {
         bazaarService.getTweetDispatcher().handleAuthCallback(bazaarService.getDBConnection(),
                 buildTwitterAuthRedirectUri(), code);
 
-        return Response.ok().build();
+        return Response.ok("You can close this tab now.").build();
     }
 
     private String buildTwitterAuthRedirectUri() {

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TweetDispatcher.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TweetDispatcher.java
@@ -1,0 +1,95 @@
+package de.rwth.dbis.acis.bazaar.service.twitter;
+
+import java.util.*;
+
+import i5.las2peer.logging.L2pLogger;
+import io.github.redouane59.twitter.TwitterClient;
+import io.github.redouane59.twitter.dto.others.BearerToken;
+import io.github.redouane59.twitter.signature.Scope;
+import io.github.redouane59.twitter.signature.TwitterCredentials;
+
+public class TweetDispatcher {
+
+    private final L2pLogger logger = L2pLogger.getInstance(TweetDispatcher.class.getName());
+
+    private final String clientId;
+    private final String clientSecret;
+
+    // Keep this in-memory for now
+    // Next step: -> store token in database
+    private BearerToken tempBearerToken;
+
+    public TweetDispatcher(String clientId, String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+
+        logger.info("Twitter clientId: " + clientId);
+        logger.info("Twitter clientSecret: " + clientSecret);
+    }
+
+
+    public void publishTweet(String text) {
+        TwitterClient twitterClient = createAuthenticatedTwitterClient();
+        logger.info("Publishing Tweet: " + text);
+
+        // TODO Implement me
+    }
+
+    // TODO Should this be more dynamic (e.g., some encoding of user who started auth process) ?
+    private static final String CODE_CHALLENGE = "req-baz-challenge";
+
+    public String getAuthorizationUrl(String redirectUri) {
+        TwitterClient twitterClient = createTwitterClientForAuthentication();
+
+        return twitterClient.getRequestHelperV2().getAuthorizeUrl(clientId, redirectUri,
+                "state",
+                CODE_CHALLENGE,
+                "plain",
+                Arrays.asList(Scope.TWEET_READ, Scope.TWEET_WRITE, Scope.USERS_READ, Scope.OFFLINE_ACCESS));
+    }
+
+    public void handleAuthCallback(String redirectUri, String code) {
+        TwitterClient twitterClient = createTwitterClientForAuthentication();
+
+        // BearerToken bearerToken = twitterClient.getOAuth2AccessToken(clientId, clientSecret, code, CODE_CHALLENGE, redirectUri);
+        // workaround because above method has NO SUPPORT for clientSecret
+        BearerToken bearerToken = TwitterClientSecretSupport.getOAuth2AccessTokenWithSecret(twitterClient,
+                clientId, clientSecret, code, CODE_CHALLENGE, redirectUri);
+
+        logger.info("Twitter accessToken: " + bearerToken.getAccessToken());
+        logger.info("Twitter refreshToken: " + bearerToken.getRefreshToken());
+
+        // store in-memory
+        this.tempBearerToken = bearerToken;
+        // TODO Store in database
+    }
+
+    /**
+     * Create a {@link TwitterClient} to be used for the authentication process (get access token etc.)
+     *
+     * @return
+     */
+    private TwitterClient createTwitterClientForAuthentication() {
+        return new TwitterClient(TwitterCredentials.builder()
+                .apiKey("gMPXcP40Nf2Fm2pqOb8Nd4MNR")
+                .apiSecretKey("pdC8TwRxiw50DglEvFIt7ryIkW56Bq4y0UfLEHp5wtdHYzZhQ2")
+                .build());
+    }
+
+    /**
+     * Create {@link TwitterClient} which can make authenticated requests on behalf of the
+     * ReqBaz Twitter account.
+     *
+     * @return
+     */
+    private TwitterClient createAuthenticatedTwitterClient() {
+        /*
+         * TODO Check expired and refresh if necessary.
+         */
+        return new TwitterClient(TwitterCredentials.builder()
+                .apiKey("gMPXcP40Nf2Fm2pqOb8Nd4MNR")
+                        .apiSecretKey("pdC8TwRxiw50DglEvFIt7ryIkW56Bq4y0UfLEHp5wtdHYzZhQ2")
+                .accessToken(tempBearerToken.getAccessToken())
+                .build());
+    }
+}

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TweetDispatcher.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TweetDispatcher.java
@@ -1,10 +1,11 @@
 package de.rwth.dbis.acis.bazaar.service.twitter;
 
-import java.util.*;
+import java.util.Arrays;
 
 import i5.las2peer.logging.L2pLogger;
 import io.github.redouane59.twitter.TwitterClient;
 import io.github.redouane59.twitter.dto.others.BearerToken;
+import io.github.redouane59.twitter.dto.tweet.TweetParameters;
 import io.github.redouane59.twitter.signature.Scope;
 import io.github.redouane59.twitter.signature.TwitterCredentials;
 
@@ -27,12 +28,20 @@ public class TweetDispatcher {
         logger.info("Twitter clientSecret: " + clientSecret);
     }
 
-
+    /**
+     * Publishes a plain text Tweet.
+     *
+     * @param text the text of the Tweet
+     */
     public void publishTweet(String text) {
         TwitterClient twitterClient = createAuthenticatedTwitterClient();
         logger.info("Publishing Tweet: " + text);
 
-        // TODO Implement me
+        final TweetParameters tweetParameters = TweetParameters.builder()
+                .text(text)
+                .build();
+
+        TwitterClientBearerTokenRequestSupport.postTweet(twitterClient, tweetParameters);
     }
 
     // TODO Should this be more dynamic (e.g., some encoding of user who started auth process) ?

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TwitterClientBearerTokenRequestSupport.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TwitterClientBearerTokenRequestSupport.java
@@ -1,0 +1,79 @@
+package de.rwth.dbis.acis.bazaar.service.twitter;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import i5.las2peer.logging.L2pLogger;
+import io.github.redouane59.twitter.TwitterClient;
+import io.github.redouane59.twitter.dto.tweet.TweetParameters;
+import io.github.redouane59.twitter.dto.tweet.TweetV2;
+import okhttp3.*;
+
+public class TwitterClientBearerTokenRequestSupport {
+
+    private static final L2pLogger logger = L2pLogger.getInstance(TwitterClientBearerTokenRequestSupport.class.getName());
+
+    private static OkHttpClient httpClient = new OkHttpClient();
+
+    TwitterClientBearerTokenRequestSupport() {
+    }
+
+    /**
+     * Posts a tweet for the user who is authenticated by the credentials configured for the given {@link TwitterClient}.
+     *
+     * @param twitterClient
+     * @param tweetParameters
+     * @return
+     */
+    public static TweetV2 postTweet(TwitterClient twitterClient, TweetParameters tweetParameters) {
+        String url = twitterClient.getUrlHelper().getPostTweetUrl();
+        return doAccessTokenAuthenticatedRequest(twitterClient, url, tweetParameters, TweetV2.class);
+    }
+
+    /**
+     * Executes an authenticated request to the given URL with the given request data.<br>
+     * <br>
+     * The request is authenticated using the <i>access token</i> set for the {@link TwitterClient}.
+     *
+     * <i>NOTE</i>: This method is a workaround for doing user-specific v2 requests to the Twitter API
+     * which is currently not supported by the {@link TwitterClient} library.
+     *
+     * @param twitterClient
+     * @param url
+     * @param requestData
+     * @param responseType
+     * @param <T>
+     * @return
+     */
+    public static <T> T doAccessTokenAuthenticatedRequest(TwitterClient twitterClient, String url, Object requestData, Class<T> responseType) {
+        String requestBodyJson;
+        try {
+            requestBodyJson = twitterClient.OBJECT_MAPPER.writeValueAsString(requestData);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to write request data as JSON", e);
+        }
+
+        String accessToken = twitterClient.getTwitterCredentials().getAccessToken();
+
+        /*
+         * We do the request by directly using OkHttpClient instead of TwitterClient because
+         * support for access token based v2 APIs is not implemented properly yet!
+         */
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("Authorization", "Bearer " + accessToken)
+                .post(RequestBody.create(MediaType.parse("application/json"), requestBodyJson))
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                logger.severe("Twitter API request failed: " + response);
+                throw new RuntimeException("Unexpected API response code: " + response.code());
+            }
+
+            return twitterClient.OBJECT_MAPPER.readValue(response.body().byteStream(), responseType);
+        } catch (IOException e) {
+            throw new RuntimeException("Exception during Twitter API request", e);
+        }
+    }
+}

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TwitterClientSecretSupport.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TwitterClientSecretSupport.java
@@ -55,4 +55,36 @@ public class TwitterClientSecretSupport {
                 .makeRequest(Verb.POST, url, headers, params, null, false, BearerToken.class)
                 .orElseThrow(NoSuchElementException::new);
     }
+
+    /**
+     * Variant of {@link TwitterClient#getOAuth2RefreshToken(String, String)}
+     * that uses <i>clientId</i> and <i>clientSecret</i> for authorization.<br>
+     *
+     * @param twitterClient
+     * @param clientId
+     * @param clientSecret
+     * @param refreshToken
+     * @return
+     */
+    public static BearerToken refreshOAuth2AccessTokenWithSecret(
+            TwitterClient twitterClient,
+            String clientId,
+            String clientSecret,
+            String refreshToken) {
+
+        String url = URLHelper.ACCESS_TOKEN_URL;
+        Map<String, String> params = new HashMap<>();
+        params.put("client_id", clientId);
+        params.put("refresh_token", refreshToken);
+        params.put("grant_type", "refresh_token");
+
+        String valueToEncode = clientId + ":" + clientSecret;
+        String encodedValue = Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Basic " + encodedValue);
+
+        return twitterClient.getRequestHelperV2()
+                .makeRequest(Verb.POST, url, headers, params, null, false, BearerToken.class)
+                .orElseThrow(NoSuchElementException::new);
+    }
 }

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TwitterClientSecretSupport.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/twitter/TwitterClientSecretSupport.java
@@ -1,0 +1,58 @@
+package de.rwth.dbis.acis.bazaar.service.twitter;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import com.github.scribejava.core.model.Verb;
+import io.github.redouane59.twitter.TwitterClient;
+import io.github.redouane59.twitter.dto.others.BearerToken;
+import io.github.redouane59.twitter.helpers.URLHelper;
+
+public class TwitterClientSecretSupport {
+
+    private TwitterClientSecretSupport() {
+    }
+
+    // TODO Create issue in TwitterClient library to support client secret out of the box!
+    /**
+     * Variant of {@link TwitterClient#getOAuth2AccessToken(String, String, String, String)}
+     * that uses <i>clientId</i> and <i>clientSecret</i> for authorization.<br>
+     * <br>
+     * This is required for applications configured as <i>confidential client</i> in the Twitter Developer Console.
+     *
+     * @param twitterClient
+     * @param clientId
+     * @param clientSecret
+     * @param code
+     * @param codeVerifier
+     * @param redirectUri
+     * @return
+     */
+    public static BearerToken getOAuth2AccessTokenWithSecret(
+            TwitterClient twitterClient,
+            String clientId,
+            String clientSecret,
+            String code,
+            String codeVerifier,
+            String redirectUri) {
+
+        String url = URLHelper.ACCESS_TOKEN_URL;
+        Map<String, String> params = new HashMap<>();
+        params.put("client_id", clientId);
+        params.put("code", code);
+        params.put("redirect_uri", redirectUri);
+        params.put("code_verifier", codeVerifier);
+        params.put("grant_type", "authorization_code");
+
+        String valueToEncode = clientId + ":" + clientSecret;
+        String encodedValue = Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Basic " + encodedValue);
+
+        return twitterClient.getRequestHelperV2()
+                .makeRequest(Verb.POST, url, headers, params, null, false, BearerToken.class)
+                .orElseThrow(NoSuchElementException::new);
+    }
+}

--- a/reqbaz/src/main/resources/changelog.yaml
+++ b/reqbaz/src/main/resources/changelog.yaml
@@ -1,5 +1,45 @@
 databaseChangeLog:
   - changeSet:
+      id: 22-03-07-add-linked-twitter-account
+      author: fxjordan
+      changes:
+        - createTable:
+            tableName: linked_twitter_account
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: linked_twitter_acc_pkey
+                  name: id
+                  type: INTEGER
+              - column:
+                  name: twitter_username
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: linked_by_user_id
+                  type: INTEGER
+              - column:
+                  name: access_token
+                  type: TEXT
+              - column:
+                  name: refresh_token
+                  type: TEXT
+              - column:
+                  constraints:
+                    nullable: false
+                  defaultValueComputed: now()
+                  name: creation_date
+                  type: TIMESTAMP WITH TIME ZONE
+              - column:
+                  name: last_updated_date
+                  type: TIMESTAMP WITH TIME ZONE
+              - column:
+                  name: expiration_date
+                  type: TIMESTAMP WITH TIME ZONE
+  - changeSet:
       id: 1624138981933-1
       author: thore (generated)
       changes:


### PR DESCRIPTION
- System Admins can link a Twitter account to Requirements Bazaar
- Access token / refresh tokens are stored in database so Twitter API can be used by ReqBaz automatically
- Simple `TweetDispatcher` component that can be used by other code to tweet plain text

Still To-DO:
- First use case with tweeting capability by weekly Tweeting about new projects
- ~~Remove hard-coded API keys~~
- ~~Refresh access token automatically using refresh token when it's expired~~