### PR TITLE
Release: v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ the [GitHub Release Page](https://github.com/rwth-acis/RequirementsBazaar/releas
 
 ## [Unreleased]
 
+## [0.12.3] - 2022-04-23
+
+### Changed
+- Stopped dispatching 'project update' notifications when GitHub webhook updates project
+  [#154](https://github.com/rwth-acis/RequirementsBazaar/pull/154)
+- Fixed not working pagination for `/categories/{id}/requirements` and `/requirements` resources. The `page` and
+  `perPage` query params were ignored before which resulted in all requirements being returned with the first request.
+  [#156](https://github.com/rwth-acis/RequirementsBazaar/pull/156)
+
 ## [0.12.1] - 2022-04-10
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel=true
 java.version=14
 core.version=1.1.2
-service.version=0.12.1
+service.version=0.12.3
 service.name=de.rwth.dbis.acis.bazaar.service
 service.class=BazaarService
 jooq.version=3.14.4

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/repositories/RequirementRepositoryImpl.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/dal/repositories/RequirementRepositoryImpl.java
@@ -178,6 +178,8 @@ public class RequirementRepositoryImpl extends RepositoryImpl<Requirement, Requi
                 .leftOuterJoin(REQUIREMENT_CATEGORY_MAP).on(REQUIREMENT.ID.eq(REQUIREMENT_CATEGORY_MAP.REQUIREMENT_ID))
                 .where(requirementFilter)
                 .and(isAuthorizedCondition)
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
                 .fetch();
 
         for (Record queryResult : queryResults) {

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/WebhookResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/WebhookResource.java
@@ -205,10 +205,7 @@ public class WebhookResource {
 
                     // save the updated Project additionalProperties
                     projectToReturn.setAdditionalProperties(objectNode);
-                    Project updatedProject = dalFacade.modifyProject(projectToReturn);
-
-                    bazaarService.getNotificationDispatcher().dispatchNotification(OffsetDateTime.now(), Activity.ActivityAction.UPDATE,
-                            MonitoringEvent.SERVICE_CUSTOM_ERROR_6,updatedProject.getId(), Activity.DataType.PROJECT, internalUserId);
+                    dalFacade.modifyProject(projectToReturn);
 
                     // close db connection
                     bazaarService.closeDBConnection(dalFacade);


### PR DESCRIPTION
### Changed
- Stopped dispatching 'project update' notifications when GitHub webhook updates project
  [#154](https://github.com/rwth-acis/RequirementsBazaar/pull/154)
- Fixed not working pagination for `/categories/{id}/requirements` and `/requirements` resources. The `page` and
  `perPage` query params were ignored before which resulted in all requirements being returned with the first request.
  [#156](https://github.com/rwth-acis/RequirementsBazaar/pull/156)
