### PR TITLE
Release: v0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ the [GitHub Release Page](https://github.com/rwth-acis/RequirementsBazaar/releas
 
 ## [Unreleased]
 
+### Changed
+- Creator of a requirement is always allowed to delete the requirement (independent of roles and privileges)
+  [#159](https://github.com/rwth-acis/RequirementsBazaar/pull/159)
+
+
 ## [0.12.3] - 2022-04-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ the [GitHub Release Page](https://github.com/rwth-acis/RequirementsBazaar/releas
 
 ## [Unreleased]
 
+## [0.12.4] - 2022-04-26
+
 ### Changed
 - Creator of a requirement is always allowed to delete the requirement (independent of roles and privileges)
   [#159](https://github.com/rwth-acis/RequirementsBazaar/pull/159)
+- Stop redirecting to requirement resource after DELETE on user vote (`/bazaar/requirements/{id}/votes`).
+  This caused some clients which are strictly implementing HTTP spec to delete the requirement too when the request
+  should only remove the vote of a user. See [#141](https://github.com/rwth-acis/RequirementsBazaar/pull/141)
 
 
 ## [0.12.3] - 2022-04-23

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel=true
 java.version=14
 core.version=1.1.2
-service.version=0.12.3
+service.version=0.12.4
 service.name=de.rwth.dbis.acis.bazaar.service
 service.class=BazaarService
 jooq.version=3.14.4

--- a/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/RequirementsResource.java
+++ b/reqbaz/src/main/java/de/rwth/dbis/acis/bazaar/service/resources/RequirementsResource.java
@@ -1109,10 +1109,7 @@ public class RequirementsResource {
                 ExceptionHandler.getInstance().throwException(ExceptionLocation.BAZAARSERVICE, ErrorCode.AUTHORIZATION, Localization.getInstance().getResourceBundle().getString("error.authorization.vote.delete"));
             }
             dalFacade.unVote(internalUserId, requirementId);
-            Requirement requirement = dalFacade.getRequirementById(requirementId, internalUserId);
-            bazaarService.getNotificationDispatcher().dispatchNotification(OffsetDateTime.now(), Activity.ActivityAction.UNVOTE, MonitoringEvent.SERVICE_CUSTOM_MESSAGE_36,
-                    requirementId, Activity.DataType.REQUIREMENT, internalUserId);
-            return Response.status(Response.Status.SEE_OTHER).location(URI.create(bazaarService.getBaseURL() + "requirements/" + requirementId)).entity(requirement.toJSON()).build();
+            return Response.noContent().build();
         } catch (BazaarException bex) {
             if (bex.getErrorCode() == ErrorCode.AUTHORIZATION) {
                 return Response.status(Response.Status.UNAUTHORIZED).entity(ExceptionHandler.getInstance().toJSON(bex)).build();


### PR DESCRIPTION
### Changed
- Creator of a requirement is always allowed to delete the requirement (independent of roles and privileges)
  [#159](https://github.com/rwth-acis/RequirementsBazaar/pull/159)
- Stop redirecting to requirement resource after DELETE on user vote (`/bazaar/requirements/{id}/votes`).
  This caused some clients which are strictly implementing HTTP spec to delete the requirement too when the request
  should only remove the vote of a user. See [#141](https://github.com/rwth-acis/RequirementsBazaar/pull/141)
