### PR TITLE
fix: migrate to new OIDC domain

### DIFF
--- a/etc/i5.las2peer.webConnector.WebConnector.properties
+++ b/etc/i5.las2peer.webConnector.WebConnector.properties
@@ -11,5 +11,5 @@ preferLocalServices = TRUE
 xmlPath =
 defaultLoginUser=anonymous
 defaultLoginPassword=anonymous
-oidcProviders = https://api.learning-layers.eu/o/oauth2,https://accounts.google.com
-#oidcProviders = http://api.learning-layers.eu:8081/auth/realms/main,https://accounts.google.com
+oidcProviders = https://auth.las2peer.org/o/oauth2,https://accounts.google.com
+#oidcProviders = http://auth.las2peer.org.eu:8081/auth/realms/main,https://accounts.google.com


### PR DESCRIPTION
Changed OIDC domain from `api.learning-layers.eu` to `auth.las2peer.org`

See internal documentation for more: https://moodle.tech4comp.dbis.rwth-aachen.de/mod/forum/discuss.php?d=1307#p3126